### PR TITLE
change event.draggingFile to event.draggingExternal

### DIFF
--- a/events_max.js
+++ b/events_max.js
@@ -50,7 +50,7 @@
 //
 //Custom drag & drop event attributes:
 //
-//	event.draggingFile: true if a file is being dragged into the browser window
+//	event.draggingExternal: true if an object external to the viewport is being dragged (e.g., a file, bookmark, or browser tab)
 
 //There are a few custom attributes used by this script that must not be manipulated:
 // ._handlerGUID on handler functions
@@ -170,8 +170,8 @@
 			if(!obj._eventHandlers["mouseleave"]) obj._eventHandlers["mouseleave"] = { capture: [], bubble: [] };
 		}
 		else if(/^drag|^drop/.test(type)){
-			//make sure the object's window handles the dragstart & dragend events so that  `draggingStarted` will be updated if it's not
-			// a file being dragged into the window
+			//make sure all dragstart & dragend events are handled so that we know the object being dragged is not external to the viewport
+			//the event doesn't have to bubble to window; it just needs to be handled at least once so that `draggingStarted` will be updated by patchEvent()
 			addTypeHandler(ownerWindow, "dragstart");
 			addTypeHandler(ownerWindow, "dragend");
 			
@@ -402,7 +402,7 @@
 		
 		/***** execute handlers for currentTarget *****/
 		
-		//execute the handlers for this phase (in FIFO order)
+		//execute the handlers for this phase (in FIFO order) if propagation has not stopped
 		if(!evtInfo.propagationStopped || (evt.eventPhase === 2 && evtInfo.propagationStoppedAtTarget && !evtInfo.propagationStoppedImmediately)){
 			
 			if(!window.addEventListener){	//IE lte 8
@@ -573,10 +573,10 @@
 		
 		/*** drag & drop attributes ***/
 		
-		//add custom `draggingFile` attribute
+		//add custom `draggingExternal` attribute
 		if(/^drag|^drop/.test(evt.type)){
 			if(evt.type === "dragstart") draggingStarted = true;
-			evt.draggingFile = !draggingStarted;
+			evt.draggingExternal = !draggingStarted;
 			if(evt.type === "dragend") draggingStarted = false;
 		}
 		

--- a/test_events_max.css
+++ b/test_events_max.css
@@ -72,6 +72,9 @@ body {
 #dropzone.dropFile {
 	border-color:#F9C;
 }
+#dropzone.dropExt {
+	border-color:#EE9;
+}
 #dropzone.dropOther {
 	border-color:#3F8;
 }

--- a/test_events_max.htm
+++ b/test_events_max.htm
@@ -75,8 +75,11 @@
 				addEventHandler(dropzone, "dragenter", function (evt){
 						evt.preventDefault();	//prevent the default handling (what handling???)
 						log(evt);
-						if(evt.draggingFile){
+						if(evt.draggingExternal && evt.dataTransfer.types && Array.prototype.indexOf.call(evt.dataTransfer.types, "Files") >= 0){
 							dropzone.className = "dropFile";
+						}
+						else if(evt.draggingExternal){
+							dropzone.className = "dropExt";
 						}
 						else{
 							dropzone.className = "dropOther";
@@ -108,8 +111,11 @@
 						addEventHandler(dropzone, "dragenter", function (evt){
 								evt.preventDefault();	//prevent the default handling (what handling???)
 								log(evt, {}, "in iframe");
-								if(evt.draggingFile){
+								if(evt.draggingExternal && evt.dataTransfer.types && Array.prototype.indexOf.call(evt.dataTransfer.types, "Files") >= 0){
 									dropzone.className = "dropFile";
+								}
+								else if(evt.draggingExternal){
+									dropzone.className = "dropExt";
 								}
 								else{
 									dropzone.className = "dropOther";

--- a/test_events_max_iframe.htm
+++ b/test_events_max_iframe.htm
@@ -24,6 +24,9 @@
 		#dropzone.dropFile {
 			border-color:#F9C;
 		}
+		#dropzone.dropExt {
+			border-color:#EE9;
+		}
 		#dropzone.dropOther {
 			border-color:#3F8;
 		}
@@ -51,8 +54,11 @@
 				addEventHandler(dropzone, "dragenter", function (evt){
 						evt.preventDefault();	//prevent the default handling (what handling???)
 						log(evt, {}, "in iframe");
-						if(evt.draggingFile){
+						if(evt.draggingExternal && evt.dataTransfer.types && Array.prototype.indexOf.call(evt.dataTransfer.types, "Files") >= 0){
 							dropzone.className = "dropFile";
+						}
+						else if(evt.draggingExternal){
+							dropzone.className = "dropExt";
 						}
 						else{
 							dropzone.className = "dropOther";


### PR DESCRIPTION
change `event.draggingFile` to `event.draggingExternal`

A file isn't the only object you can drag into the viewport. For example, it could be an item on your favorites bar or even a browser tab.

Updated the test pages so the drop zones change to different colors based on if the object being dragged originated inside or outside of the viewport, and if it was outside, whether "Files" is one of its types. (green=inside, pink=external file, beige=other external)
